### PR TITLE
Issue usage info

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+# When requesting a feature
+
+As a ..
+
+I want to ..
+
+So that..
+
+### Additional information if feature request
+
+Give us some extra information about the desired feature.
+
+# When reporting a bug
+
+### Subject of the issue
+Describe your issue here.
+
+### Your environment
+* Version of CoMPAS
+* Which browser and its version
+
+### Steps to reproduce
+Tell us how to reproduce this issue.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead

--- a/docs/HOME.md
+++ b/docs/HOME.md
@@ -60,13 +60,15 @@ Note that checks will be performed during the integration in order to require th
 
 ### Reporting Bugs and Suggesting Enhancements
 
-Bugs and enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue 
-and provide the following information by filling in [the template](ISSUE_TEMPLATE.md).
+Bugs and enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue in the repository where it belongs (an issue about the CIM to IEC 61850 mapping belongs in the [CIM Mapping repository](https://github.com/com-pas/compas-cim-mapping) for example) and provide the following information by filling in [the template](../.github/ISSUE_TEMPLATE.md). If your request is a feature, you only need to fill in the `When requesting a feature` section. If it's a bug, fill in the `When reporting a bug` section.
+
+When an issue is created, it is automatically being added to the `To do` column of the specific repository. This means it's added, but not yet refined. Every monday at 10AM CET, there is a Community Refinement (see our mailing list [calendar](https://lists.lfenergy.org/g/CoMPAS/calendar), everybody can join) where issues are being discussed that are not refined yet. Your issue is one of them.
+Once it's accepted and refined, it goes to the `Ready for development` column and it's ready to be implemented/fixed.
 
 Before creating bug reports or suggesting enhancement, please **perform a [cursory search](https://github.com/search?q=+is%3Aissue+user%3Acom-pas)** 
-to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+to see if the problem has already been reported. You can add a search term to the upper left search bar. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 
-You can also contact the team directly to talk about your ideas at [CoMPAS-dev@lists.lfenergy.org](mailto:CoMPAS-dev@lists.lfenergy.org).
+When in doubt, ask your question on our [LFEnergy slack](https://lfenergy.slack.com/) in the `#compas` channel. Or you can contact the team directly to talk about your ideas at [CoMPAS-dev@lists.lfenergy.org](mailto:CoMPAS@lists.lfenergy.org).
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -16,10 +16,11 @@ request is used to generate the release notes.
   - ``enhancement``: The pull request adds as a new feature.
   - ``bug``: The pull request solves a bugfix.
   - ``tooling``: Change or update to tooling used to build project.
+- **Linking issue**: Link the correct issue using one of the [keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) in the description, for example `closes #1234`. **This only works when the PR is being merged to the default branch**.
 
 There is a special label  ``dependencies`` used by dependabot for updating dependencies.
-These are grouped together in a separate section.  
-If no label is added the pull request will be added to the section ``Other Changes`` at the bottom of the release notes. 
+These are grouped together in a separate section.
+If no label is added the pull request will be added to the section ``Other Changes`` at the bottom of the release notes.
 
 The following labels cause the pull request to be ignored in the release notes:
 - ``wontfix``

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -19,7 +19,7 @@ request is used to generate the release notes.
 
 There is a special label  ``dependencies`` used by dependabot for updating dependencies.
 These are grouped together in a separate section.  
-If no label is added the pull request will be added to the section ``Other Changes`` at the bottom of the release notes.
+If no label is added the pull request will be added to the section ``Other Changes`` at the bottom of the release notes. 
 
 The following labels cause the pull request to be ignored in the release notes:
 - ``wontfix``


### PR DESCRIPTION
Proposal how to use issues / pull requests.
If accepted, we can implement it on all repositories.

Labels is already explained quite well in the Pull Requests section.

For issues I propose to use an issue template.
When an issue is created, it's added to the `To do` column of the specific repository.
After the refinement of that issue, it's being moved to the `Ready for development` column (which must be added).
This takes away to usage of the labels `Refinement needed` and `Refinement done` for example, which is AND more work AND sensitive for mistakes.